### PR TITLE
Oliver/immutability is the best

### DIFF
--- a/src/linear_model.rs
+++ b/src/linear_model.rs
@@ -28,7 +28,7 @@ where
 fn tanh<T: Numeric + Real>(tensor: RcTensor<T>) -> RcTensor<T> {
     let length = tensor.shape().iter().fold(1, |acc, x| acc * *x);
     let mut array = Vec::with_capacity(length);
-    for &elem in ElementIterator::new(&tensor) {
+    for elem in ElementIterator::new(&tensor) {
         array.push(elem.tanh());
     }
     RcTensor::new(array, tensor.shape().clone())
@@ -37,7 +37,7 @@ fn tanh<T: Numeric + Real>(tensor: RcTensor<T>) -> RcTensor<T> {
 fn tanh_derivative<T: Numeric + Real>(tensor: RcTensor<T>) -> RcTensor<T> {
     let length = tensor.shape().iter().fold(1, |acc, x| acc * *x);
     let mut array = Vec::with_capacity(length);
-    for &elem in ElementIterator::new(&tensor) {
+    for elem in ElementIterator::new(&tensor) {
         let _v = T::one() - T::one() / elem.tanh().powi(2);
         array.push(elem.tanh());
     }

--- a/src/linear_model.rs
+++ b/src/linear_model.rs
@@ -1,19 +1,19 @@
-use super::tensor::{ElementIterator, Numeric, Tensor, TensorLike};
+use super::tensor::{ElementIterator, Numeric, RcTensor, TensorLike};
 use num::traits::real::Real;
 
 pub struct LinearLayer<T>
 where
     T: Numeric,
 {
-    weights: Tensor<T>,
-    bias: Tensor<T>,
+    weights: RcTensor<T>,
+    bias: RcTensor<T>,
 }
 
 impl<T> LinearLayer<T>
 where
     T: Numeric,
 {
-    pub fn forward<U>(&self, batch: &U) -> Tensor<T>
+    pub fn forward<U>(&self, batch: &U) -> RcTensor<T>
     where
         U: TensorLike<Elem = T>,
     {
@@ -25,28 +25,28 @@ where
     }
 }
 
-fn tanh<T: Numeric + Real>(tensor: Tensor<T>) -> Tensor<T> {
+fn tanh<T: Numeric + Real>(tensor: RcTensor<T>) -> RcTensor<T> {
     let length = tensor.shape().iter().fold(1, |acc, x| acc * *x);
     let mut array = Vec::with_capacity(length);
     for &elem in ElementIterator::new(&tensor) {
         array.push(elem.tanh());
     }
-    Tensor::new(array, tensor.shape().clone())
+    RcTensor::new(array, tensor.shape().clone())
 }
 
-fn tanh_derivative<T: Numeric + Real>(tensor: Tensor<T>) -> Tensor<T> {
+fn tanh_derivative<T: Numeric + Real>(tensor: RcTensor<T>) -> RcTensor<T> {
     let length = tensor.shape().iter().fold(1, |acc, x| acc * *x);
     let mut array = Vec::with_capacity(length);
     for &elem in ElementIterator::new(&tensor) {
         let _v = T::one() - T::one() / elem.tanh().powi(2);
         array.push(elem.tanh());
     }
-    Tensor::new(array, tensor.shape().clone())
+    RcTensor::new(array, tensor.shape().clone())
 }
 
 #[test]
 fn test_tanh_derivative() {
-    let input = Tensor::new((0..64).collect(), vec![4, 4, 4]);
+    let input = RcTensor::new((0..64).collect(), vec![4, 4, 4]);
     // let epsilon = 1e-7 as f64;
     // let epsilon_tensor = Tensor::new_with_filler(epsilon, vec![4, 4, 4]);
     // let perturbed_input = &input + &epsilon_tensor;
@@ -62,12 +62,12 @@ fn test_tanh_derivative() {
 #[test]
 fn test_layer() {
     let layer = LinearLayer {
-        weights: Tensor::new_with_filler(vec![1, 2, 2], 1),
-        bias: Tensor::new_with_filler(vec![1, 2, 1], 1),
+        weights: RcTensor::new_with_filler(vec![1, 2, 2], 1),
+        bias: RcTensor::new_with_filler(vec![1, 2, 1], 1),
     };
-    let input = Tensor::new(vec![1, 2], vec![2, 1]);
+    let input = RcTensor::new(vec![1, 2], vec![2, 1]);
     let res = layer.forward(&input);
-    let expected = Tensor::new(vec![4, 4], vec![1, 2, 1]);
+    let expected = RcTensor::new(vec![4, 4], vec![1, 2, 1]);
 
     assert_eq!(res, expected);
 }

--- a/src/linear_model.rs
+++ b/src/linear_model.rs
@@ -46,7 +46,7 @@ fn tanh_derivative<T: Numeric + Real>(tensor: RcTensor<T>) -> RcTensor<T> {
 
 #[test]
 fn test_tanh_derivative() {
-    let input = RcTensor::new((0..64).collect(), vec![4, 4, 4]);
+    let _input = RcTensor::new((0..64).collect(), vec![4, 4, 4]);
     // let epsilon = 1e-7 as f64;
     // let epsilon_tensor = Tensor::new_with_filler(epsilon, vec![4, 4, 4]);
     // let perturbed_input = &input + &epsilon_tensor;

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -10,7 +10,7 @@ pub use tensor_view::*;
 pub use utils::*;
 
 use itertools::{EitherOrBoth::*, Itertools};
-use std::cell::{Ref, RefCell};
+
 use std::cmp::{max, PartialEq};
 use std::convert::From;
 use std::ops::{Add, Deref, Index, Mul};

--- a/src/tensor/tensor_like.rs
+++ b/src/tensor/tensor_like.rs
@@ -27,9 +27,7 @@ pub trait TensorLike {
     /// for a `TensorView`, for example, the new Tensor is the same shape as the view.
     fn to_tensor(&self) -> RawTensor<Self::Elem>;
 
-    fn slice(&self, offset: Vec<SliceRange>) -> TensorView<Self::Elem> {
-        TensorView::new(*self.tensor(), offset)
-    }
+    fn slice(&self, offset: Vec<SliceRange>) -> TensorView<Self::Elem>;
 
     fn left_scalar_multiplication(&self, &scalar: &Self::Elem) -> RawTensor<Self::Elem> {
         let mut result = RawTensor::new_empty((*self.shape()).clone());

--- a/src/tensor/tensor_like.rs
+++ b/src/tensor/tensor_like.rs
@@ -12,9 +12,7 @@ pub trait TensorLike {
     where
         Self: 'a;
 
-    fn get(&self, index: &Vec<usize>) -> Result<&Self::Elem, String> {
-        (*self.tensor()).get(index)
-    }
+    fn get(&self, index: &Vec<usize>) -> Result<&Self::Elem, String>;
 
     fn shape(&self) -> Self::ShapeReturn<'_>;
 
@@ -109,7 +107,8 @@ pub trait TensorLike {
                         self_index[self_index_len - 1] = k;
                         right_index[0] = k;
                         val = val
-                            + *self.get(&self_index).unwrap() * *right.get(&right_index).unwrap();
+                            + *self.get(&self_index).unwrap().deref()
+                                * (*right.get(&right_index).unwrap().deref());
                     }
                     result.array.push(val);
                 }

--- a/src/tensor/tensor_view.rs
+++ b/src/tensor/tensor_view.rs
@@ -59,6 +59,7 @@ where
     type Elem = T;
     type ShapeReturn<'a> = &'a Vec<usize> where Self: 'a ;
     type TensorRef<'a>= RcTensor<T> where Self: 'a; // &'tensor Tensor<Self::Elem> where Self : 'tensor;
+    type ResultTensorType<'a>= RcTensor<T> where Self: 'a; // &'tensor Tensor<Self::Elem> where Self : 'tensor;
     fn shape(&self) -> Self::ShapeReturn<'_> {
         &self.shape
     }
@@ -89,6 +90,12 @@ where
 
     fn slice(&self, offset: Vec<SliceRange>) -> TensorView<T> {
         TensorView::new(self.tensor(), offset)
+    }
+    fn bmm<U>(&self, right: &U) -> Self::ResultTensorType<'_>
+    where
+        U: TensorLike<Elem = Self::Elem>,
+    {
+        self.bmm_rc(right)
     }
 }
 

--- a/src/tensor/tensor_view.rs
+++ b/src/tensor/tensor_view.rs
@@ -1,8 +1,8 @@
 use super::numeric::*;
 use crate::tensor::{ElementIterator, RawTensor, RcTensor, SliceRange, TensorLike};
-use std::cell::Ref;
+
 use std::cmp::PartialEq;
-use std::ops::{Deref, Index};
+use std::ops::{Index};
 
 #[derive(Debug, Clone)]
 pub struct TensorView<T>
@@ -22,7 +22,7 @@ where
     type Output = T;
 
     fn index(&self, index: &Vec<usize>) -> &Self::Output {
-        &self.tensor.get_with_offset(index, &self.offset).unwrap()
+        self.tensor.get_with_offset(index, &self.offset).unwrap()
     }
 }
 

--- a/src/tensor/tensor_view.rs
+++ b/src/tensor/tensor_view.rs
@@ -22,11 +22,7 @@ where
     type Output = T;
 
     fn index(&self, index: &Vec<usize>) -> &Self::Output {
-        self.tensor
-            .0
-            .borrow()
-            .get_with_offset(index, &self.offset)
-            .unwrap()
+        &self.tensor.get_with_offset(index, &self.offset).unwrap()
     }
 }
 
@@ -51,7 +47,8 @@ where
         }
     }
     pub fn to_tensor(&self) -> RawTensor<T> {
-        self.tensor.0.borrow().clone()
+        // self.tensor.clone()
+        todo!()
     }
 }
 
@@ -85,11 +82,9 @@ where
     fn get(&self, index: &Vec<usize>) -> Result<&T, String> {
         let idx = self
             .tensor
-            .0
-            .borrow()
             .get_global_index(index, Some(&self.offset))
             .unwrap();
-        Ok(&self.tensor.0.borrow().array[idx])
+        Ok(&self.tensor.array[idx])
     }
 
     fn slice(&self, offset: Vec<SliceRange>) -> TensorView<T> {

--- a/src/tensor/utils.rs
+++ b/src/tensor/utils.rs
@@ -47,9 +47,9 @@ where
 
 #[test]
 fn test_element_iterator() {
-    use crate::tensor::{SliceRange, Tensor};
+    use crate::tensor::{RcTensor, SliceRange};
     let v = [1, 2, 3];
-    let tensor = Tensor::from(v);
+    let tensor = RcTensor::from(v);
     let view = tensor.view(vec![SliceRange::new(0, 3)]);
     let tensor_element_iterator = ElementIterator::new(&tensor);
     let element_iterator = ElementIterator::new(&view);

--- a/tests/test_tensor.rs
+++ b/tests/test_tensor.rs
@@ -2,8 +2,8 @@ use rust_light::tensor::*;
 
 #[test]
 fn test_slicing() {
-    let tensor1 = Tensor::from(vec![vec![0, 1, 2], vec![3, 4, 5]]);
-    let tensor2 = Tensor::from(vec![vec![1, 2], vec![4, 5]]);
+    let tensor1 = RawTensor::from(vec![vec![0, 1, 2], vec![3, 4, 5]]);
+    let tensor2 = RawTensor::from(vec![vec![1, 2], vec![4, 5]]);
     println!(
         "{:?}\n{:?}",
         tensor1.slice(vec![SliceRange::new(0, 2), SliceRange::new(1, 2),]),
@@ -24,7 +24,7 @@ fn test_slicing() {
     assert_eq!(slice1[&vec![0, 0]], 1);
     assert_ne!(slice1, slice2);
 
-    let tensor = Tensor::new((0..32).collect(), vec![2, 4, 4]);
+    let tensor = RawTensor::new((0..32).collect(), vec![2, 4, 4]);
     let slice = tensor.slice(vec![
         SliceRange::new(1, 2),
         SliceRange::new(2, 3),
@@ -33,28 +33,28 @@ fn test_slicing() {
     assert_eq!(slice.shape(), &vec![1, 1, 3]);
     assert_eq!(
         slice,
-        Tensor::from([[[25, 26, 27].to_vec()].to_vec()].to_vec())
+        RawTensor::from([[[25, 26, 27].to_vec()].to_vec()].to_vec())
     );
 }
 
 #[test]
 fn test_from_array() {
-    let tensor1 = Tensor::from([[0, 1, 2], [3, 4, 5]]);
-    let tensor2 = Tensor::new((0..6).collect(), vec![2, 3]);
+    let tensor1 = RawTensor::from([[0, 1, 2], [3, 4, 5]]);
+    let tensor2 = RawTensor::new((0..6).collect(), vec![2, 3]);
     assert_eq!(tensor1, tensor2);
 }
 
 #[test]
 fn test_from_vec() {
-    let tensor1 = Tensor::from(vec![vec![0, 1, 2], vec![3, 4, 5]]);
-    let tensor2 = Tensor::new((0..6).collect(), vec![2, 3]);
+    let tensor1 = RawTensor::from(vec![vec![0, 1, 2], vec![3, 4, 5]]);
+    let tensor2 = RawTensor::new((0..6).collect(), vec![2, 3]);
     assert_eq!(tensor1, tensor2);
 }
 
 // #[ignore]
 #[test]
 fn test_new_with_filler() {
-    let vec = Tensor::new_with_filler(vec![4], 4);
+    let vec = RawTensor::new_with_filler(vec![4], 4);
     let shape = vec.shape();
     assert_eq!(shape, &vec![4]);
     assert_eq!(vec.get(&vec![0]).unwrap(), &4);
@@ -63,7 +63,7 @@ fn test_new_with_filler() {
 // #[ignore]
 #[test]
 fn test_get_2x2x2() {
-    let matrix = Tensor::new(vec![0, 1, 2, 3, 4, 5, 6, 7], vec![2, 2, 2]);
+    let matrix = RawTensor::new(vec![0, 1, 2, 3, 4, 5, 6, 7], vec![2, 2, 2]);
     assert_eq!(*matrix.get(&vec![0, 0, 0]).unwrap(), 0);
     assert_eq!(*matrix.get(&vec![0, 1, 0]).unwrap(), 2);
     assert_eq!(*matrix.get(&vec![1, 1, 1]).unwrap(), 7);
@@ -72,7 +72,7 @@ fn test_get_2x2x2() {
 // #[ignore]
 #[test]
 fn test_get_3x3x4() {
-    let matrix = Tensor::new((0..(3 * 3 * 4)).collect(), vec![3, 3, 4]);
+    let matrix = RawTensor::new((0..(3 * 3 * 4)).collect(), vec![3, 3, 4]);
     assert_eq!(*matrix.get(&vec![0, 0, 0]).unwrap(), 0);
     assert_eq!(*matrix.get(&vec![2, 2, 3]).unwrap(), 3 * 3 * 4 - 1);
 }
@@ -80,7 +80,7 @@ fn test_get_3x3x4() {
 // #[ignore]
 #[test]
 fn test_get_3x3() {
-    let matrix = Tensor::new(vec![0, 1, 2, 3, 4, 5, 6, 7, 8], vec![3, 3]);
+    let matrix = RawTensor::new(vec![0, 1, 2, 3, 4, 5, 6, 7, 8], vec![3, 3]);
     let mut prev = -1;
     for i in 0..3 {
         for j in 0..3 {
@@ -103,9 +103,9 @@ fn test_get_3x3() {
 #[test]
 fn test_add_scalar() {
     let val = 42;
-    let tensor1 = Tensor::new((0..32).collect(), vec![2, 4, 4]);
-    let tensor2 = Tensor::new((42..(32 + 42)).collect(), vec![2, 4, 4]);
-    let scalar = Tensor::scalar(val);
+    let tensor1 = RawTensor::new((0..32).collect(), vec![2, 4, 4]);
+    let tensor2 = RawTensor::new((42..(32 + 42)).collect(), vec![2, 4, 4]);
+    let scalar = RawTensor::scalar(val);
     assert_eq!(&tensor1 + &scalar, tensor2);
     assert_eq!(&scalar + &tensor1, tensor2);
     // assert_eq!(scalar, Tensor::from(val));
@@ -115,9 +115,9 @@ fn test_add_scalar() {
 // #[ignore]
 #[test]
 fn test_add() {
-    let tensor1 = Tensor::new_with_filler(vec![4, 4], 1);
-    let tensor2 = Tensor::new((0..32).collect(), vec![2, 4, 4]);
-    let tensor3 = Tensor::new((1..33).collect(), vec![2, 4, 4]);
+    let tensor1 = RawTensor::new_with_filler(vec![4, 4], 1);
+    let tensor2 = RawTensor::new((0..32).collect(), vec![2, 4, 4]);
+    let tensor3 = RawTensor::new((1..33).collect(), vec![2, 4, 4]);
     assert_eq!(&tensor2 + &tensor1, tensor3);
     assert_eq!(&tensor1 + &tensor2, tensor3);
 }
@@ -126,14 +126,14 @@ fn test_add() {
 #[test]
 fn test_dot() {
     let v = vec![0, 1, 2];
-    let vec = Tensor::new(v, vec![3]);
-    assert_eq!(vec.dot(&vec), Tensor::new(vec![5], vec![1]));
+    let vec = RawTensor::new(v, vec![3]);
+    assert_eq!(vec.dot(&vec), RawTensor::new(vec![5], vec![1]));
 }
 
 #[test]
 fn test_creation() {
     let v = vec![0, 1, 2, 3];
-    let matrix = Tensor::new(v, vec![2, 2]);
+    let matrix = RawTensor::new(v, vec![2, 2]);
 
     format!("Matrix: \n{:?}", matrix);
 
@@ -144,25 +144,25 @@ fn test_creation() {
 #[test]
 fn test_bmm_2x2() {
     let v = vec![0, 1, 2, 3];
-    let matrix = Tensor::new(v, vec![2, 2]); // [[0,1],[2,3]]
+    let matrix = RawTensor::new(v, vec![2, 2]); // [[0,1],[2,3]]
     let shape = vec![2, 1];
-    let e1 = Tensor::new(vec![0, 1], vec![2, 1]);
-    let e2 = Tensor::new(vec![1, 0], vec![2, 1]);
-    let diag = Tensor::new(vec![1, 1], vec![2, 1]);
+    let e1 = RawTensor::new(vec![0, 1], vec![2, 1]);
+    let e2 = RawTensor::new(vec![1, 0], vec![2, 1]);
+    let diag = RawTensor::new(vec![1, 1], vec![2, 1]);
 
     let r = matrix.bmm(&diag);
     assert_eq!(r.shape(), &shape);
-    assert_eq!(r, Tensor::new(vec![1, 5], shape.clone()));
-    assert_eq!(matrix.bmm(&e1), Tensor::new(vec![1, 3], shape.clone()));
-    assert_eq!(matrix.bmm(&e2), Tensor::new(vec![0, 2], shape.clone()));
+    assert_eq!(r, RawTensor::new(vec![1, 5], shape.clone()));
+    assert_eq!(matrix.bmm(&e1), RawTensor::new(vec![1, 3], shape.clone()));
+    assert_eq!(matrix.bmm(&e2), RawTensor::new(vec![0, 2], shape.clone()));
 }
 
 // #[ignore]
 #[test]
 fn test_right_scalar_multiplication() {
-    let vec = Tensor::new_with_filler(vec![4], 1);
+    let vec = RawTensor::new_with_filler(vec![4], 1);
     assert_eq!(
         vec.right_scalar_multiplication(&42),
-        Tensor::new(vec![42, 42, 42, 42], vec![4])
+        RawTensor::new(vec![42, 42, 42, 42], vec![4])
     );
 }


### PR DESCRIPTION
## Idea:
Make `Tensor` immutable, so that we can get it to work well with `Rc`. This opens the way to making a graph structure for autograd.

I have also renamed `Tensor`: it is now split into `RcTensor` and `RawTensor`. The idea is to reintroduce a `Tensor` when I have stabilised the API a bit further.

Thanks to @mcastorina for suggestions on this PR!