### PR TITLE
Sealing TensorLike

### DIFF
--- a/src/tensor/raw_tensor.rs
+++ b/src/tensor/raw_tensor.rs
@@ -125,25 +125,12 @@ impl<T: Numeric> RcTensor<T> {
     }
 }
 
-impl<T: Numeric> HasGrad for RawTensor<T> {
-    type GradType = RcTensor<T>;
-    fn set_grad(&self, grad: Self::GradType) {
-        *self.grad.borrow_mut() = Some(grad);
-    }
-}
-
-impl<T: Numeric> HasGrad for RcTensor<T> {
-    type GradType = RcTensor<T>;
-    fn set_grad(&self, grad: Self::GradType) {
-        *self.0.grad.borrow_mut() = Some(grad);
-    }
-}
-
 fn ones<T: Numeric>(tensors: Vec<RcTensor<T>>) -> RcTensor<T> {
     assert_eq!(tensors.len(), 1);
     RcTensor::new_with_filler(tensors[0].shape().to_vec(), T::one())
 }
 
+impl<T> TensorLikePrivate for RcTensor<T> where T: Numeric {}
 impl<T> TensorLike for RcTensor<T>
 where
     T: Numeric,
@@ -153,6 +140,11 @@ where
     type TensorRef<'a> = RcTensor<Self::Elem> where Self: 'a;
     type ResultTensorType<'a>= RcTensor<T> where Self: 'a; // &'tensor Tensor<Self::Elem> where Self : 'tensor;
     type SumType = Scalar<Self::Elem>;
+    type GradType = RcTensor<T>;
+
+    fn set_grad(&self, grad: Self::GradType) {
+        *self.grad.borrow_mut() = Some(grad);
+    }
 
     fn shape(&self) -> Self::ShapeReturn<'_> {
         self.deref().shape()
@@ -540,6 +532,7 @@ where
     }
 }
 
+impl<T> TensorLikePrivate for RawTensor<T> where T: Numeric {}
 impl<T> TensorLike for RawTensor<T>
 where
     T: Numeric,
@@ -549,6 +542,11 @@ where
     type TensorRef<'tensor> = &'tensor RawTensor<Self::Elem> where Self : 'tensor;
     type ResultTensorType<'a>= RawTensor<T> where Self: 'a; // &'tensor Tensor<Self::Elem> where Self : 'tensor;
     type SumType = Self;
+    type GradType = RcTensor<T>;
+
+    fn set_grad(&self, grad: Self::GradType) {
+        *self.grad.borrow_mut() = Some(grad);
+    }
     fn shape(&self) -> Self::ShapeReturn<'_> {
         &self.shape
     }

--- a/src/tensor/tensor_like.rs
+++ b/src/tensor/tensor_like.rs
@@ -12,14 +12,12 @@ where
 {
 }
 
-pub trait HasGrad {
-    type GradType: TensorLike;
-    fn set_grad(&self, _grad: Self::GradType) {
-        todo!();
-    }
+pub(in crate::tensor) mod private {
+    pub trait TensorLikePrivate {}
 }
+pub use crate::tensor::private::TensorLikePrivate;
 
-pub trait TensorLike: HasGrad + std::fmt::Debug {
+pub trait TensorLike: TensorLikePrivate + std::fmt::Debug {
     type Elem: Numeric;
     type ShapeReturn<'a>: Deref<Target = Vec<usize>>
     where
@@ -31,6 +29,12 @@ pub trait TensorLike: HasGrad + std::fmt::Debug {
     where
         Self: 'a;
     type SumType: TensorLike<Elem = Self::Elem>;
+    type GradType: TensorLike;
+
+    fn set_grad(&self, _grad: Self::GradType) {
+        todo!();
+    }
+
     fn get(&self, index: &Vec<usize>) -> Result<&Self::Elem, String>;
 
     #[inline]
@@ -126,7 +130,8 @@ pub trait TensorLike: HasGrad + std::fmt::Debug {
     where
         U: TensorLike<Elem = Self::Elem>,
     {
-        assert!(2 <= self.shape().len() && self.shape().len() <= 3); // For now we can only do Batch matrix
+        // assert!(2 <= self.shape().len() && self.shape().len() <= 3); // For now we can only do Batch matrix
+        assert!(2 <= self.shape().len()); // For now we can only do Batch matrix
         assert!(right.shape().len() == 2); // rhs must be a matrix
         assert!(self.shape()[self.shape().len() - 1] == right.shape()[right.shape().len() - 2]);
         let new_shape = if self.shape().len() == 2 {

--- a/src/tensor/tensor_view.rs
+++ b/src/tensor/tensor_view.rs
@@ -1,5 +1,5 @@
 use super::numeric::*;
-use crate::tensor::{ElementIterator, HasGrad, RcTensor, Scalar, SliceRange, TensorLike};
+use crate::tensor::{ElementIterator, RcTensor, Scalar, SliceRange, TensorLike, TensorLikePrivate};
 
 use std::cmp::PartialEq;
 use std::ops::Index;
@@ -52,9 +52,7 @@ where
     // }
 }
 
-impl<T: Numeric> HasGrad for TensorView<T> {
-    type GradType = RcTensor<T>;
-}
+impl<T> TensorLikePrivate for TensorView<T> where T: Numeric {}
 
 impl<T> TensorLike for TensorView<T>
 where
@@ -65,6 +63,8 @@ where
     type TensorRef<'a>= RcTensor<T> where Self: 'a; // &'tensor Tensor<Self::Elem> where Self : 'tensor;
     type ResultTensorType<'a>= RcTensor<T> where Self: 'a; // &'tensor Tensor<Self::Elem> where Self : 'tensor;
     type SumType = Scalar<Self::Elem>;
+    type GradType = RcTensor<T>;
+
     fn shape(&self) -> Self::ShapeReturn<'_> {
         &self.shape
     }


### PR DESCRIPTION
This prevents a bunch of future issues. While I would like users to be able to stick pretty much anything into a Tensor, by implementing `Numeric`, I don't want them to be able to make their own custom `TensorLike` implementations. That would make it really hard to change the core interface.