### PR TITLE
Oliver/actually set gradients and split dot into separate functional module

### DIFF
--- a/src/tensor/functional/misc.rs
+++ b/src/tensor/functional/misc.rs
@@ -1,10 +1,10 @@
 use super::super::numeric::*;
-use crate::tensor::autograd::{self, Derivative};
-use crate::tensor::utils::IndexIterator;
+use crate::tensor::autograd::{Derivative};
+
 use crate::tensor::{RawTensor, RcTensor, TensorLike};
 use std::ops::Deref;
 
-pub(crate) fn todo_deriv<T: Numeric>(inputs: Vec<RcTensor<T>>) -> RcTensor<T> {
+pub(crate) fn todo_deriv<T: Numeric>(_inputs: Vec<RcTensor<T>>) -> RcTensor<T> {
     todo!()
 }
 

--- a/src/tensor/functional/misc.rs
+++ b/src/tensor/functional/misc.rs
@@ -1,0 +1,45 @@
+use super::super::numeric::*;
+use crate::tensor::autograd::{self, Derivative};
+use crate::tensor::utils::IndexIterator;
+use crate::tensor::{RawTensor, RcTensor, TensorLike};
+use std::ops::Deref;
+
+pub(crate) fn todo_deriv<T: Numeric>(inputs: Vec<RcTensor<T>>) -> RcTensor<T> {
+    todo!()
+}
+
+pub(crate) fn dot_raw<T, U1, U2, V1, V2>(left: U1, right: U2) -> RawTensor<T>
+where
+    T: Numeric,
+    U1: Deref<Target = V1> + std::fmt::Debug + Clone,
+    V1: TensorLike<Elem = T>,
+    U2: Deref<Target = V2> + Clone + std::fmt::Debug,
+    V2: TensorLike<Elem = T>,
+{
+    //! generalised dot product: returns to acculumulated sum of the elementwise product.
+    assert!(left.same_shape(&right));
+    let mut result = T::zero();
+    for i in 0..left.tensor().array.len() {
+        result = result + left.tensor().array[i] * right.tensor().array[i];
+    }
+    RawTensor {
+        array: vec![result],
+        shape: vec![1],
+        derivative: Some(Derivative::new(
+            vec![left.to_tensor(), right.to_tensor()],
+            todo_deriv,
+        )),
+        ..Default::default()
+    }
+}
+
+pub fn dot<T, U1, U2, V1, V2>(left: U1, right: U2) -> RcTensor<T>
+where
+    T: Numeric,
+    U1: Deref<Target = V1> + std::fmt::Debug + Clone,
+    V1: TensorLike<Elem = T>,
+    U2: Deref<Target = V2> + Clone + std::fmt::Debug,
+    V2: TensorLike<Elem = T>,
+{
+    RcTensor::from_raw(dot_raw(left, right))
+}

--- a/src/tensor/functional/mod.rs
+++ b/src/tensor/functional/mod.rs
@@ -1,0 +1,3 @@
+pub mod misc;
+
+pub use misc::*;

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -1,4 +1,5 @@
 mod autograd;
+pub mod functional;
 mod numeric;
 mod raw_tensor;
 mod rc_tensor;
@@ -7,6 +8,7 @@ mod tensor_view;
 mod utils;
 
 pub use autograd::Derivative;
+// pub use functional;
 pub use numeric::*;
 pub use raw_tensor::*;
 pub use rc_tensor::*;

--- a/src/tensor/raw_tensor.rs
+++ b/src/tensor/raw_tensor.rs
@@ -7,6 +7,7 @@ use std::convert::From;
 use std::ops::{Add, Deref, Index, Mul, Neg, Sub};
 
 use super::autograd::{self, Derivative};
+use super::functional as F;
 use super::numeric::*;
 use super::rc_tensor::*;
 use super::tensor_like::*;
@@ -33,11 +34,6 @@ impl SliceRange {
     }
 }
 
-// DEBUG: disabling test till more features are in
-// #[ignore]
-// #[test]
-// fn test_user_tensor_multiplication() {}
-//
 /// The core `struct` in this library.
 #[derive(Debug, Clone)]
 pub struct RawTensor<T>
@@ -357,6 +353,14 @@ where
     type ResultTensorType<'a>= RawTensor<T> where Self: 'a; // &'tensor Tensor<Self::Elem> where Self : 'tensor;
     type SumType = Self;
     type GradType = RcTensor<T>;
+
+    fn dot<U, V>(&self, other: U) -> RcTensor<Self::Elem>
+    where
+        U: Deref<Target = V> + std::fmt::Debug + Clone,
+        V: TensorLike<Elem = Self::Elem>,
+    {
+        F::dot(self, other)
+    }
 
     fn set_grad(&self, grad: Self::GradType) {
         *self.grad.borrow_mut() = Some(grad);

--- a/src/tensor/rc_tensor.rs
+++ b/src/tensor/rc_tensor.rs
@@ -1,19 +1,16 @@
 use std::rc::Rc;
 
-
-
-
 use std::cell::RefCell;
-use std::cmp::{PartialEq};
+use std::cmp::PartialEq;
 use std::convert::From;
 use std::ops::{Deref, Mul};
 
-use super::autograd::{Derivative};
+use super::autograd::Derivative;
+use super::functional as F;
 use super::numeric::*;
 use super::raw_tensor::*;
 use super::tensor_like::*;
 use super::tensor_view::*;
-
 
 fn ones<T: Numeric>(tensors: Vec<RcTensor<T>>) -> RcTensor<T> {
     assert_eq!(tensors.len(), 1);
@@ -122,6 +119,14 @@ where
 
     fn set_grad(&self, grad: Self::GradType) {
         *self.grad.borrow_mut() = Some(grad);
+    }
+
+    fn dot<U, V>(&self, other: U) -> RcTensor<Self::Elem>
+    where
+        U: Deref<Target = V> + std::fmt::Debug + Clone,
+        V: TensorLike<Elem = Self::Elem>,
+    {
+        F::dot(self, other)
     }
 
     fn shape(&self) -> Self::ShapeReturn<'_> {

--- a/src/tensor/tensor_like.rs
+++ b/src/tensor/tensor_like.rs
@@ -1,5 +1,5 @@
-use super::autograd::{self, Derivative};
-use super::functional as F;
+
+
 use super::numeric::*;
 use super::utils::IndexIterator;
 use super::{RawTensor, RcTensor, SliceRange, TensorView};

--- a/src/tensor/tensor_view.rs
+++ b/src/tensor/tensor_view.rs
@@ -1,8 +1,9 @@
+use super::functional as F;
 use super::numeric::*;
 use crate::tensor::{ElementIterator, RcTensor, Scalar, SliceRange, TensorLike, TensorLikePrivate};
 
 use std::cmp::PartialEq;
-use std::ops::Index;
+use std::ops::{Deref, Index};
 
 #[derive(Debug, Clone)]
 pub struct TensorView<T>
@@ -64,6 +65,14 @@ where
     type ResultTensorType<'a>= RcTensor<T> where Self: 'a; // &'tensor Tensor<Self::Elem> where Self : 'tensor;
     type SumType = Scalar<Self::Elem>;
     type GradType = RcTensor<T>;
+
+    fn dot<U, V>(&self, other: U) -> RcTensor<Self::Elem>
+    where
+        U: Deref<Target = V> + std::fmt::Debug + Clone,
+        V: TensorLike<Elem = Self::Elem>,
+    {
+        F::dot(self, other)
+    }
 
     fn shape(&self) -> Self::ShapeReturn<'_> {
         &self.shape

--- a/tests/test_tensor.rs
+++ b/tests/test_tensor.rs
@@ -123,12 +123,6 @@ fn test_add() {
 }
 
 // #[ignore]
-#[test]
-fn test_dot() {
-    let v = vec![0, 1, 2];
-    let vec = RawTensor::new(v, vec![3]);
-    assert_eq!(vec.dot(&vec), RawTensor::new(vec![5], vec![1]));
-}
 
 #[test]
 fn test_creation() {
@@ -165,12 +159,4 @@ fn test_right_scalar_multiplication() {
         vec.right_scalar_multiplication(&42),
         RawTensor::new(vec![42, 42, 42, 42], vec![4])
     );
-}
-
-#[test]
-fn test_element_wise_multiplication() {
-    let left = RcTensor::from([1, 2, 3]);
-    let right = RcTensor::from([7, 2, 8]);
-    dbg!("left={}, right={},", &left, &right);
-    assert_eq!(&left * &right, RcTensor::from([7, 4, 24]));
 }


### PR DESCRIPTION
This finally allows us to access gradients with `RawTensor.grad`, however there is still much work to be done.

This PR also splits `dot` into a separate functional module, since that allows for even more genericness, and will likely make it easier to do the autograd things. At the moment it is looking tricky.

Then next key thing to get done is dealing with multiple inputs, such as in `dot`.