### PR TITLE
Oliver/more efficient and flexible chain rule for scalars

### DIFF
--- a/src/tensor/autograd/mod.rs
+++ b/src/tensor/autograd/mod.rs
@@ -1,9 +1,9 @@
 use super::numeric::*;
 use crate::tensor::functional;
-use crate::tensor::*;
+
 use crate::tensor::{ElementIterator, RawTensor, RcTensor, TensorLike};
 use num::traits::real::Real;
-use std::ops::Deref;
+
 use std::rc::Rc;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -91,14 +91,13 @@ impl<T: Numeric> Derivative<T> {
         // f(g(h(x))) how do i set x.grad if we are now computing f'
         // grad = f'(g(hx)) g'(h(x)) h'(x)
         // f(g(h(x), z)) how do i set x.grad if we are now computing f'
-        let self_grads = (self.backward)(self.inputs.clone(), outer_grads.clone());
+        let self_grads = (self.backward)(self.inputs.clone(), outer_grads);
         let self_grad = self_grads[0].clone();
         self.inputs[0].set_grad(self_grad.clone());
         let new_grad = dbg!(self_grad);
-        self.inputs[0]
+        if let Some(d) = self.inputs[0]
             .derivative
-            .as_ref()
-            .map(|d| d.compute_grads(vec![new_grad]));
+            .as_ref() { d.compute_grads(vec![new_grad]) }
     }
 }
 
@@ -233,7 +232,7 @@ fn test_multi_dimensional_tanh() {
 #[test]
 fn test_tanh_twice_sets_grad() {
     // TODO: get this to work with non-scalar inputs
-    let input = RcTensor::from([[0.666, 12.0], [-3.2, -0.1]]);
+    let _input = RcTensor::from([[0.666, 12.0], [-3.2, -0.1]]);
     let input = RcTensor::from([0.666]);
     let epsilon = 1e-12 as f64;
     let output = tanh(&tanh(&input)).sum();

--- a/src/tensor/functional/misc.rs
+++ b/src/tensor/functional/misc.rs
@@ -1,10 +1,16 @@
 use super::super::numeric::*;
-use crate::tensor::autograd::{Derivative};
+use crate::tensor::autograd::Derivative;
 
 use crate::tensor::{RawTensor, RcTensor, TensorLike};
 use std::ops::Deref;
 
-pub(crate) fn todo_deriv<T: Numeric>(_inputs: Vec<RcTensor<T>>) -> RcTensor<T> {
+pub(crate) fn todo_backward<T: Numeric>(
+    _inputs: Vec<RcTensor<T>>,
+    _grads: Vec<RcTensor<T>>,
+) -> Vec<RcTensor<T>> {
+    todo!()
+}
+pub(crate) fn todo_deriv<T: Numeric>(_inputs: Vec<RcTensor<T>>) -> Vec<RcTensor<T>> {
     todo!()
 }
 
@@ -25,15 +31,11 @@ where
     RawTensor {
         array: vec![result],
         shape: vec![1],
-        derivative: Some(Derivative::new(
-            vec![left.to_tensor(), right.to_tensor()],
-            todo_deriv,
-        )),
         ..Default::default()
     }
 }
 
-pub fn dot<T, U1, U2, V1, V2>(left: U1, right: U2) -> RcTensor<T>
+pub fn dot_no_derivative<T, U1, U2, V1, V2>(left: U1, right: U2) -> RcTensor<T>
 where
     T: Numeric,
     U1: Deref<Target = V1> + std::fmt::Debug + Clone,
@@ -42,4 +44,26 @@ where
     V2: TensorLike<Elem = T>,
 {
     RcTensor::from_raw(dot_raw(left, right))
+}
+
+// TODO: generalise this to views
+pub fn dot<T>(left: &RcTensor<T>, right: &RcTensor<T>) -> RcTensor<T>
+where
+    T: Numeric,
+{
+    let mut raw_tensor = dot_raw(left, right);
+    raw_tensor.derivative = Some(Derivative::new(
+        vec![left.clone(), right.clone()],
+        todo_deriv,
+        None,
+    ));
+
+    RcTensor::from_raw(raw_tensor)
+}
+
+#[test]
+fn test_dot() {
+    let v = vec![0, 1, 2];
+    let vec = RcTensor::new(v, vec![3]);
+    assert_eq!(dot(&vec, &vec), RcTensor::new(vec![5], vec![1]));
 }

--- a/src/tensor/raw_tensor.rs
+++ b/src/tensor/raw_tensor.rs
@@ -517,9 +517,9 @@ where
     }
 
     // dbg!("array={}, shape={},", &array, &left_shape_vec,);
-    let result = RawTensor::new(array, left_shape_vec);
+    
     // dbg!("result={:?}", &result);
-    result
+    RawTensor::new(array, left_shape_vec)
 }
 
 impl<T, U, V> Mul<U> for &RawTensor<T>

--- a/src/tensor/raw_tensor.rs
+++ b/src/tensor/raw_tensor.rs
@@ -359,7 +359,7 @@ where
         U: Deref<Target = V> + std::fmt::Debug + Clone,
         V: TensorLike<Elem = Self::Elem>,
     {
-        F::dot(self, other)
+        F::dot_no_derivative(self, other)
     }
 
     fn set_grad(&self, grad: Self::GradType) {
@@ -412,7 +412,11 @@ where
     fn add(self, right: &U) -> Self::Output {
         let mut raw_tensor = self.deref().add(right);
         // TODO: set derivative struct for right too
-        raw_tensor.derivative = Some(Derivative::new(vec![self.to_tensor()], autograd::ones));
+        raw_tensor.derivative = Some(Derivative::new(
+            vec![self.to_tensor()],
+            autograd::ones,
+            None,
+        ));
         RcTensor::from_raw(raw_tensor)
     }
 }
@@ -507,14 +511,14 @@ where
     assert!(left_shape_vec == right.shape().to_vec());
     let length = left.shape().iter().product();
     let mut array = Vec::with_capacity(length);
-    dbg!("left={}, right={},", left.clone(), right.clone());
+    // dbg!("left={}, right={},", left.clone(), right.clone());
     for (x, y) in ElementIterator::new(left).zip(ElementIterator::new(right)) {
         array.push(x * y);
     }
 
-    dbg!("array={}, shape={},", &array, &left_shape_vec,);
+    // dbg!("array={}, shape={},", &array, &left_shape_vec,);
     let result = RawTensor::new(array, left_shape_vec);
-    dbg!("result={:?}", &result);
+    // dbg!("result={:?}", &result);
     result
 }
 

--- a/src/tensor/rc_tensor.rs
+++ b/src/tensor/rc_tensor.rs
@@ -5,17 +5,17 @@ use std::cmp::PartialEq;
 use std::convert::From;
 use std::ops::{Deref, Mul};
 
-use super::autograd::Derivative;
+use super::autograd::{self, Derivative};
 use super::functional as F;
 use super::numeric::*;
 use super::raw_tensor::*;
 use super::tensor_like::*;
 use super::tensor_view::*;
 
-fn ones<T: Numeric>(tensors: Vec<RcTensor<T>>) -> RcTensor<T> {
-    assert_eq!(tensors.len(), 1);
-    RcTensor::new_with_filler(tensors[0].shape().to_vec(), T::one())
-}
+// fn ones<T: Numeric>(tensors: Vec<RcTensor<T>>) -> RcTensor<T> {
+//     assert_eq!(tensors.len(), 1);
+//     RcTensor::new_with_filler(tensors[0].shape().to_vec(), T::one())
+// }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct RcTensor<T: Numeric>(pub(super) Rc<RawTensor<T>>);
@@ -105,6 +105,16 @@ impl<T: Numeric> RcTensor<T> {
     }
 }
 
+fn sum_backward<T: Numeric>(inputs: Vec<RcTensor<T>>, grads: Vec<RcTensor<T>>) -> Vec<RcTensor<T>> {
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(grads.len(), 1);
+    assert_eq!(grads[0].0.array.len(), 1);
+    vec![RcTensor::new_with_filler(
+        inputs[0].shape().to_vec(),
+        *grads[0].get_first_elem(),
+    )]
+}
+
 impl<T> TensorLikePrivate for RcTensor<T> where T: Numeric {}
 impl<T> TensorLike for RcTensor<T>
 where
@@ -118,7 +128,9 @@ where
     type GradType = RcTensor<T>;
 
     fn set_grad(&self, grad: Self::GradType) {
+        let grad_clone = grad.clone();
         *self.grad.borrow_mut() = Some(grad);
+        dbg!("setting grads:", self.clone(), grad_clone);
     }
 
     fn dot<U, V>(&self, other: U) -> RcTensor<Self::Elem>
@@ -126,7 +138,7 @@ where
         U: Deref<Target = V> + std::fmt::Debug + Clone,
         V: TensorLike<Elem = Self::Elem>,
     {
-        F::dot(self, other)
+        todo!()
     }
 
     fn shape(&self) -> Self::ShapeReturn<'_> {
@@ -139,7 +151,11 @@ where
 
     fn sum(&self) -> Self::SumType {
         let mut raw_scalar = self.0.sum();
-        raw_scalar.derivative = Some(Derivative::new(vec![self.clone()], ones));
+        raw_scalar.derivative = Some(Derivative::new(
+            vec![self.clone()],
+            autograd::ones,
+            Some(sum_backward),
+        ));
         Scalar::from_raw(raw_scalar)
     }
 

--- a/src/tensor/rc_tensor.rs
+++ b/src/tensor/rc_tensor.rs
@@ -6,7 +6,7 @@ use std::convert::From;
 use std::ops::{Deref, Mul};
 
 use super::autograd::{self, Derivative};
-use super::functional as F;
+
 use super::numeric::*;
 use super::raw_tensor::*;
 use super::tensor_like::*;
@@ -133,7 +133,7 @@ where
         dbg!("setting grads:", self.clone(), grad_clone);
     }
 
-    fn dot<U, V>(&self, other: U) -> RcTensor<Self::Elem>
+    fn dot<U, V>(&self, _other: U) -> RcTensor<Self::Elem>
     where
         U: Deref<Target = V> + std::fmt::Debug + Clone,
         V: TensorLike<Elem = Self::Elem>,

--- a/src/tensor/tensor_like.rs
+++ b/src/tensor/tensor_like.rs
@@ -1,5 +1,3 @@
-
-
 use super::numeric::*;
 use super::utils::IndexIterator;
 use super::{RawTensor, RcTensor, SliceRange, TensorView};
@@ -121,6 +119,7 @@ pub trait TensorLike: TensorLikePrivate + std::fmt::Debug {
         U: TensorLike<Elem = Self::Elem>,
     {
         // assert!(2 <= self.shape().len() && self.shape().len() <= 3); // For now we can only do Batch matrix
+        dbg!(self.shape().to_vec());
         assert!(2 <= self.shape().len()); // For now we can only do Batch matrix
         assert!(right.shape().len() == 2); // rhs must be a matrix
         assert!(self.shape()[self.shape().len() - 1] == right.shape()[right.shape().len() - 2]);
@@ -194,11 +193,4 @@ pub trait TensorLike: TensorLikePrivate + std::fmt::Debug {
     fn iter_indices(&self) -> IndexIterator {
         IndexIterator::new(self.shape().clone())
     }
-}
-
-#[test]
-fn test_dot() {
-    let v = vec![0, 1, 2];
-    let vec = RcTensor::new(v, vec![3]);
-    assert_eq!(vec.dot(&vec), RcTensor::new(vec![5], vec![1]));
 }

--- a/src/tensor/tensor_view.rs
+++ b/src/tensor/tensor_view.rs
@@ -71,7 +71,7 @@ where
         U: Deref<Target = V> + std::fmt::Debug + Clone,
         V: TensorLike<Elem = Self::Elem>,
     {
-        F::dot(self, other)
+        todo!()
     }
 
     fn shape(&self) -> Self::ShapeReturn<'_> {

--- a/src/tensor/tensor_view.rs
+++ b/src/tensor/tensor_view.rs
@@ -1,4 +1,4 @@
-use super::functional as F;
+
 use super::numeric::*;
 use crate::tensor::{ElementIterator, RcTensor, Scalar, SliceRange, TensorLike, TensorLikePrivate};
 
@@ -66,7 +66,7 @@ where
     type SumType = Scalar<Self::Elem>;
     type GradType = RcTensor<T>;
 
-    fn dot<U, V>(&self, other: U) -> RcTensor<Self::Elem>
+    fn dot<U, V>(&self, _other: U) -> RcTensor<Self::Elem>
     where
         U: Deref<Target = V> + std::fmt::Debug + Clone,
         V: TensorLike<Elem = Self::Elem>,


### PR DESCRIPTION
This means that all gradients are set on the backward pass, which is quite a bit more efficient.

There is still a lot to do: most notably fix things for the multivariable case