### PR TITLE
Oliver/switch to computing jacobian vector product

### DIFF
--- a/src/tensor/autograd/mod.rs
+++ b/src/tensor/autograd/mod.rs
@@ -1,5 +1,5 @@
 use super::numeric::*;
-use crate::tensor::functional;
+
 
 use crate::tensor::{ElementIterator, RawTensor, RcTensor, TensorLike};
 use num::traits::real::Real;

--- a/src/tensor/autograd/mod.rs
+++ b/src/tensor/autograd/mod.rs
@@ -71,7 +71,7 @@ impl<T: Numeric> Derivative<T> {
         // f(g(h(x))) how do i set x.grad if we are now computing f'
         // grad = f'(g(hx)) g'(h(x)) h'(x)
         // f(g(h(x), z)) how do i set x.grad if we are now computing f'
-        let self_grads = (self.jacobian_vector_product)(self.inputs.clone(), outer_grads.clone());
+        let self_grads = (self.jacobian_vector_product)(self.inputs.clone(), outer_grads);
         let grad = self_grads[0].clone();
         let shaped_grad = RcTensor::new(grad.0.array.clone(), self.inputs[0].shape().to_vec());
         self.inputs[0].set_grad(shaped_grad);

--- a/src/tensor/functional/misc.rs
+++ b/src/tensor/functional/misc.rs
@@ -75,7 +75,6 @@ where
     raw_tensor.derivative = Some(Derivative::new(
         vec![left.clone(), right.clone()],
         todo_deriv,
-        None,
     ));
 
     RcTensor::from_raw(raw_tensor)

--- a/src/tensor/functional/misc.rs
+++ b/src/tensor/functional/misc.rs
@@ -2,7 +2,6 @@ use super::super::numeric::*;
 use crate::tensor::autograd::Derivative;
 use crate::tensor::utils::ElementIterator;
 
-
 use crate::tensor::{RawTensor, RcTensor, TensorLike};
 use std::ops::Deref;
 
@@ -36,7 +35,6 @@ where
         ..Default::default()
     }
 }
-
 
 pub fn element_wise_multiplication<T, U1, V1, U2, V2>(left: U1, right: U2) -> RawTensor<T>
 where

--- a/src/tensor/functional/misc.rs
+++ b/src/tensor/functional/misc.rs
@@ -11,7 +11,10 @@ pub(crate) fn todo_backward<T: Numeric>(
 ) -> Vec<RcTensor<T>> {
     todo!()
 }
-pub(crate) fn todo_deriv<T: Numeric>(_inputs: Vec<RcTensor<T>>) -> Vec<RcTensor<T>> {
+pub(crate) fn todo_deriv<T: Numeric>(
+    _inputs: Vec<RcTensor<T>>,
+    _: Vec<RcTensor<T>>,
+) -> Vec<RcTensor<T>> {
     todo!()
 }
 

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -7,8 +7,6 @@ mod tensor_like;
 mod tensor_view;
 mod utils;
 
-pub use autograd::Derivative;
-// pub use functional;
 pub use numeric::*;
 pub use raw_tensor::*;
 pub use rc_tensor::*;

--- a/src/tensor/raw_tensor.rs
+++ b/src/tensor/raw_tensor.rs
@@ -413,11 +413,7 @@ where
     fn add(self, right: &U) -> Self::Output {
         let mut raw_tensor = self.deref().add(right);
         // TODO: set derivative struct for right too
-        raw_tensor.derivative = Some(Derivative::new(
-            vec![self.to_tensor()],
-            autograd::ones,
-            None,
-        ));
+        raw_tensor.derivative = Some(Derivative::new(vec![self.to_tensor()], autograd::ones));
         RcTensor::from_raw(raw_tensor)
     }
 }

--- a/src/tensor/raw_tensor.rs
+++ b/src/tensor/raw_tensor.rs
@@ -500,7 +500,6 @@ where
     }
 }
 
-
 impl<T, U, V> Mul<U> for &RawTensor<T>
 where
     T: Numeric,

--- a/src/tensor/rc_tensor.rs
+++ b/src/tensor/rc_tensor.rs
@@ -109,10 +109,7 @@ fn sum_backward<T: Numeric>(inputs: Vec<RcTensor<T>>, grads: Vec<RcTensor<T>>) -
     assert_eq!(inputs.len(), 1);
     assert_eq!(grads.len(), 1);
     assert_eq!(grads[0].0.array.len(), 1);
-    vec![RcTensor::new_with_filler(
-        inputs[0].shape().to_vec(),
-        *grads[0].get_first_elem(),
-    )]
+    vec![RcTensor::from([*grads[0].get_first_elem()])]
 }
 
 impl<T> TensorLikePrivate for RcTensor<T> where T: Numeric {}


### PR DESCRIPTION
Update the autograd idioms to work with JVPs which is more efficient (though the current tanh implementation is pretty terrible, as it needlessly computes a full jacobian.)
Working with the JVP is also conceptually more straightforward: compute the jacobian then matrix multiply with the incoming jacobian/gradient/scalar.
If you want you can optimise this, or not.

