### PR TITLE
Oliver/small bmm bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "itertools"
@@ -22,6 +39,12 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.146"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "num"
@@ -100,9 +123,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "rust_light"
 version = "0.1.0"
 dependencies = [
  "itertools",
  "num",
+ "rand",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2021"
 [dependencies]
 num="0.4.0"
 itertools="0.10.5"
+
+
+[dev-dependencies]
+rand = "0.8.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,15 @@
 // use rust_light as rlt;
 use rust_light::nn::linear::Linear;
 use rust_light::optim::sgd::sgd_step;
-use rust_light::tensor::{Numeric, RcTensor, TensorLike};
+use rust_light::tensor::{RcTensor, TensorLike};
 
 fn main() {
     let mut layer = Linear::new(
         RcTensor::from([[1.0, -2.0], [-1.1, 0.7]]),
-        RcTensor::new_with_filler(vec![1, 2, 1], 1.0),
+        RcTensor::new_with_filler(vec![1, 2], 1.0),
         None,
     );
-    let input = RcTensor::new(vec![1.0, 2.0], vec![2, 1]);
+    let input = RcTensor::new(vec![1.0, 2.0], vec![1, 2]);
     let res = layer.forward(input);
     res.sum().backward();
     layer.weights.grad();

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+
 
 use num::traits::real::Real;
 

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -17,13 +17,10 @@ impl<T> Linear<T>
 where
     T: Numeric + Real,
 {
-    pub fn forward<U, V>(&self, batch_ref: U) -> RcTensor<T>
-    where
-        U: Deref<Target = V> + std::fmt::Debug + Clone,
-        V: TensorLike<Elem = T>,
-    {
+    pub fn forward(&self, batch_ref: RcTensor<T>) -> RcTensor<T> {
         let batch = batch_ref.to_tensor();
-        let y = self.weights.bmm(&batch);
+        // let y = self.weights.bmm(&batch);
+        let y = batch.bmm(&self.weights);
 
         (self.activation)(&y + &self.bias)
     }
@@ -56,13 +53,13 @@ where
 #[test]
 fn test_layer_no_grad() {
     let layer = Linear::new(
-        RcTensor::new_with_filler(vec![1, 2, 2], 1.0),
-        RcTensor::new_with_filler(vec![1, 2, 1], 1.0),
+        RcTensor::new_with_filler(vec![2, 2], 1.0),
+        RcTensor::new_with_filler(vec![1, 2], 1.0),
         None,
     );
-    let input = RcTensor::new(vec![1.0, 2.0], vec![2, 1]);
+    let input = RcTensor::new(vec![1.0, 2.0], vec![1, 2]);
     let res = layer.forward(input);
-    let expected = RcTensor::new(vec![4.0, 4.0], vec![1, 2, 1]);
+    let expected = RcTensor::new(vec![4.0, 4.0], vec![1, 2]);
 
     assert_eq!(res, expected);
 }
@@ -71,17 +68,16 @@ fn test_layer_no_grad() {
 fn test_layer() {
     let layer = Linear::new(
         RcTensor::from([[1.0, -2.0], [-1.1, 0.7]]),
-        RcTensor::new_with_filler(vec![1, 2, 1], 1.0),
+        RcTensor::new_with_filler(vec![1, 2], 1.0),
         None,
     );
-    let input = RcTensor::new(vec![1.0, 2.0], vec![2, 1]);
+    let input = RcTensor::new(vec![1.0, 2.0], vec![1, 2]);
     let res = layer.forward(input);
     res.sum().backward();
     layer.weights.grad();
     layer.bias.grad();
 }
 
-#[ignore]
 #[test]
 fn test_layer_batch_tensor() {
     // TODO: figure out how to update bmm to work correctly with autograd

--- a/src/tensor/functional/element_wise_ops.rs
+++ b/src/tensor/functional/element_wise_ops.rs
@@ -67,8 +67,8 @@ fn tanh_derivative<T: Numeric + Real>(
             array.push(v);
         }
     }
-    let result = RcTensor::new(array, vec![length, length]);
-    result
+    
+    RcTensor::new(array, vec![length, length])
 }
 
 pub(crate) fn add<T, U1, U2, V1, V2>(left: U1, right: U2) -> RcTensor<T>
@@ -301,7 +301,7 @@ fn generic_unary_jvp<T: Numeric>(
         }
     }
     let diag = RcTensor::new(array, diag_shape);
-    vec![jvp_from_diagonal(&diag, Some(&jvp_shape), &grad)]
+    vec![jvp_from_diagonal(&diag, Some(&jvp_shape), grad)]
 }
 
 pub fn generic_unary_op<T, U, V>(tensor_like: U, op: fn(T) -> T) -> RawTensor<T>

--- a/src/tensor/raw_tensor.rs
+++ b/src/tensor/raw_tensor.rs
@@ -1,4 +1,4 @@
-use num::traits::real::Real;
+
 
 use std::cell::RefCell;
 use std::cmp::PartialEq;

--- a/src/tensor/tensor_like.rs
+++ b/src/tensor/tensor_like.rs
@@ -12,7 +12,7 @@ pub use crate::tensor::private::TensorLikePrivate;
 
 pub trait TensorLike: TensorLikePrivate + std::fmt::Debug {
     type Elem: Numeric;
-    type ShapeReturn<'a>: Deref<Target = Vec<usize>>
+    type ShapeReturn<'a>: Deref<Target = Vec<usize>> + std::fmt::Debug
     where
         Self: 'a;
     type TensorRef<'a>: Deref<Target = RawTensor<Self::Elem>>


### PR DESCRIPTION
This gets the linear layer a little better -- this converts `forward` to have the same matrix multiplication order as torch's linear layer