### PR TITLE
Oliver/make bmm jvp parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +60,16 @@ dependencies = [
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -272,6 +296,7 @@ dependencies = [
 name = "rust_light"
 version = "0.2.0"
 dependencies = [
+ "crossbeam",
  "itertools",
  "num",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num="0.4.0"
+crossbeam = "0.8.2"
 itertools="0.10.5"
-rayon = "1.7.0"
+num="0.4.0"
 rand = "0.8.5"
 rand_distr = "0.4.0"
+rayon = "1.7.0"


### PR DESCRIPTION
Parallelised computing the jacobian for matrix multiplication. This is was by far the most computationally intensive part of training a neural network.

It looks like this gives a ~30% speedup to training. (measured on a 2020 M1 Mac)

I have been finding `samply` very handy for profiling this code!